### PR TITLE
feat(api): add magic link support

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,6 +24,7 @@ env:
   TF_VAR_git_sha: ${{ github.sha }}
   TF_VAR_authorizer_dsn: ${{ secrets.SENTRY_AUTHORIZER_DSN }}
   TF_VAR_proxy_dsn: ${{ secrets.SENTRY_PROXY_DSN }}
+  TF_VAR_magic_link_blob: ${{ secrets.MAGIC_LINK_BLOB_PRODUCTION }}
 
 jobs:
   release:
@@ -46,6 +47,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           TWITCH_CLIENT_ID: op://ci-cd/foam-staging/TWITCH_PROD_CLIENT_ID
           TWITCH_CLIENT_SECRET: op://ci-cd/foam-staging/TWITCH_PROD_CLIENT_SECRET
+          TF_VAR_magic_link_api_key: op://ci-cd/foam-staging/MAGIC_LINK_API_KEY
           OP_ENV_FILE: ".env"
 
       - name: Set Terraform variables

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,6 +21,7 @@ env:
   TF_VAR_certificate_chain: ${{ secrets.CERTIFICATE_CHAIN }}
   TF_VAR_deployed_by: ${{ github.actor }}
   TF_VAR_git_sha: ${{ github.sha }}
+  TF_VAR_magic_link_blob: ${{ secrets.MAGIC_LINK_BLOB_STAGING }}
 
 jobs:
   release:
@@ -43,6 +44,7 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           TWITCH_CLIENT_ID: op://ci-cd/foam-staging/TWITCH_CLIENT_ID
           TWITCH_CLIENT_SECRET: op://ci-cd/foam-staging/TWITCH_CLIENT_SECRET
+          TF_VAR_magic_link_api_key: op://ci-cd/foam-staging/MAGIC_LINK_API_KEY
           PROXY_DSN: op://ci-cd/foam-staging/SENTRY_PROXY_DSN
           AUTHORIZER_DSN: op://ci-cd/foam-staging/SENTRY_AUTH_DSN
           OP_ENV_FILE: ".env"

--- a/.github/workflows/refresh-magic-link.yml
+++ b/.github/workflows/refresh-magic-link.yml
@@ -17,13 +17,10 @@ jobs:
     name: Refresh ${{ matrix.env }} magic link token
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Per-environment group: a slow/queued staging run must not block production.
     concurrency:
       group: refresh-magic-link-${{ matrix.env }}
       cancel-in-progress: false
     strategy:
-      # Independent blobs — one env failing (e.g. its secret is unset) must not
-      # cancel the other.
       fail-fast: false
       matrix:
         include:

--- a/.github/workflows/refresh-magic-link.yml
+++ b/.github/workflows/refresh-magic-link.yml
@@ -1,0 +1,69 @@
+name: Refresh magic link
+
+# Keeps each environment's App Review magic link baked access token fresh. Twitch
+# user access tokens last ~4h and the app does not refresh on login, so refresh
+# ahead of that. Staging and production each have their own blob, write-back secret
+# and Lambda, minted against their own Twitch app, so they refresh independently.
+on:
+  schedule:
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Refresh ${{ matrix.env }} magic link token
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Per-environment group: a slow/queued staging run must not block production.
+    concurrency:
+      group: refresh-magic-link-${{ matrix.env }}
+      cancel-in-progress: false
+    strategy:
+      # Independent blobs — one env failing (e.g. its secret is unset) must not
+      # cancel the other.
+      fail-fast: false
+      matrix:
+        include:
+          - env: staging
+            lambda: foam-proxy-lambda-staging
+            blob_secret: MAGIC_LINK_BLOB_STAGING
+            twitch_client_id_ref: op://ci-cd/foam-staging/TWITCH_CLIENT_ID
+            twitch_client_secret_ref: op://ci-cd/foam-staging/TWITCH_CLIENT_SECRET
+          - env: production
+            lambda: foam-proxy-lambda-production
+            blob_secret: MAGIC_LINK_BLOB_PRODUCTION
+            twitch_client_id_ref: op://ci-cd/foam-staging/TWITCH_PROD_CLIENT_ID
+            twitch_client_secret_ref: op://ci-cd/foam-staging/TWITCH_PROD_CLIENT_SECRET
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Load secrets
+        uses: 1password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          TWITCH_CLIENT_ID: ${{ matrix.twitch_client_id_ref }}
+          TWITCH_CLIENT_SECRET: ${{ matrix.twitch_client_secret_ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          mask-aws-account-id: true
+
+      - name: Refresh token and update blob
+        env:
+          MAGIC_LINK_BLOB: ${{ secrets[matrix.blob_secret] }}
+          MAGIC_LINK_BLOB_SECRET: ${{ matrix.blob_secret }}
+          GH_TOKEN: ${{ secrets.MAGIC_LINK_PAT }}
+          LAMBDA_FUNCTION_NAME: ${{ matrix.lambda }}
+        run: ./scripts/refresh-magic-link.sh

--- a/README.md
+++ b/README.md
@@ -8,6 +8,83 @@ Lambda which supports authentication proxying for [foam](https://github.com/luke
 - [Terraform](https://www.terraform.io/)
 - [git-cliff](https://github.com/orhun/git-cliff) for changelog and version bumps
 
+## App Review magic link
+
+`GET /api/magic?key=<secret>` is a backdoor for Apple App Review. The app requires
+a Twitch login with 2FA, which reviewers can't complete, so this redirects into
+the app with a stored test-account session (`foam://auth?access_token=…&refresh_token=…`),
+bypassing OAuth. The route is public but gated by a constant-time secret check —
+a wrong/missing key returns `404` so the route never reveals itself.
+
+Appending `&format=json` returns the raw session blob instead of the redirect page,
+behind the same key check. The blob always carries `access_token`, `refresh_token`
+and `token_type` (defaulting to `bearer`); `expires_in` is included only when known.
+This lets an in-app App Review login fetch the token and inject it directly (via
+`loginWithTwitch`) rather than bouncing through the `foam://auth` deep link.
+
+### Targeting a build variant (`&scheme=`)
+
+By default the magic link redirects to `foam://auth`. Because a custom scheme is
+shared across whatever apps claim it, that opens whichever build the OS picks
+(usually production). Append `&scheme=<variant>` to redirect into a specific build
+that registers that scheme instead:
+
+```
+GET /api/magic?key=<secret>&scheme=foam-internal   → foam-internal://auth?access_token=…
+```
+
+Only allowlisted schemes are accepted (`foam`, `foam-dev`, `foam-internal`,
+`foam-testflight`, `foam-e2e` — see `allowedAppSchemes` in `internal/config`);
+anything else falls back to `foam`, so the route can't be abused to bounce a token
+into an arbitrary scheme. Omitting it preserves the production default, which is
+what App Review uses. The override is magic-link only — the interactive OAuth
+routes (`/api/proxy`, `/api/pending`) always target `foam`.
+
+The `?key` secret lives in its own `MAGIC_LINK_API_KEY` env var — one shared gate
+key for both environments, sourced from `op://ci-cd/foam-staging/MAGIC_LINK_API_KEY`
+during deploy — kept separate from the token data so the gate secret is decoupled
+from the rotating blob. The session lives in a per-environment GitHub secret —
+`MAGIC_LINK_BLOB_STAGING` or `MAGIC_LINK_BLOB_PRODUCTION` — a JSON blob:
+
+```json
+{ "access_token": "…", "refresh_token": "…", "expires_in": 14400, "token_type": "bearer" }
+```
+
+Each env has its own blob, minted against that env's Twitch app and refreshed
+independently — Twitch binds a refresh token to its minting client id.
+
+### Setup
+
+Run `scripts/setup-magic-link.sh --env <prod|staging>` once per environment (needs
+the `twitch`, `gh`, `op`, `jq` CLIs). It mints the token and prints the blob, gate
+key and review URL as JSON; you store them. Per env:
+
+1. Create a disposable, low-privilege Twitch test account (never a personal one).
+2. Run the script for the env — it points the Twitch CLI at that env's app and
+   mints a user token with all of the app's scopes (Device Code Flow, so you get a
+   `refresh_token`). The gate key is generated for you (`MAGIC_LINK_API_KEY` is just
+   an opaque high-entropy string).
+3. Store `.magic_link_blob` in the env's GitHub secret (`MAGIC_LINK_BLOB_STAGING` /
+   `MAGIC_LINK_BLOB_PRODUCTION`). The gate key is shared: prod setup also yields
+   `.magic_link_api_key` — store it once in `op://ci-cd/foam-staging/MAGIC_LINK_API_KEY`
+   (both deploys read it); staging reuses it.
+4. Set the `MAGIC_LINK_PAT` GitHub secret to a fine-grained PAT with **Secrets:
+   write** (the refresh cron uses it to rotate the blobs).
+5. Hand Apple the `.review_url.browser` value in App Review notes.
+6. After approval, revoke the token (`--teardown`) and clear the secrets.
+
+### Staying fresh
+
+The app signs in with the baked `access_token` immediately and does **not** refresh
+on failure, so a stale token breaks the review login. The **Refresh magic link**
+workflow (`.github/workflows/refresh-magic-link.yml`) runs every 3h with one job per
+environment: each refreshes its blob via the `refresh_token`, persists the new blob
+to that env's GitHub secret (canonical, so a later `terraform apply` stays fresh) and
+then updates the live Lambda env (immediate). Twitch rotates the refresh token on each
+refresh, so the write-back needs `MAGIC_LINK_PAT`; without it the run fails rather than
+rotating a token it can't persist. Run it manually after storing a blob to seed the
+first refresh.
+
 ## Changelog & version
 
 Changelog is generated from conventional commits. On push to `main`, the **Changelog** workflow updates `CHANGELOG.md` and commits it.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,14 +12,9 @@ import (
 
 const (
 	defaultTwitchTimeout = 20 * time.Second
-	// DefaultAppScheme is the production app's custom URL scheme, used when a
-	// deployment doesn't set APP_SCHEME.
-	DefaultAppScheme = "foam"
+	DefaultAppScheme     = "foam"
 )
 
-// allowedAppSchemes are the custom URL schemes the Foam app registers, one per
-// build variant (see app.config.ts). Redirects are restricted to these so the
-// magic/proxy routes can't be used to bounce a token into an arbitrary scheme.
 var allowedAppSchemes = map[string]bool{
 	"foam":            true,
 	"foam-dev":        true,
@@ -28,14 +23,10 @@ var allowedAppSchemes = map[string]bool{
 	"foam-e2e":        true,
 }
 
-// IsAllowedAppScheme reports whether scheme is a known Foam variant scheme.
 func IsAllowedAppScheme(scheme string) bool {
 	return allowedAppSchemes[scheme]
 }
 
-// ResolveAppScheme returns requested when it's a known variant scheme, otherwise
-// the production default. requested comes from the untrusted ?scheme query param,
-// so the allowlist stops the redirect from targeting an arbitrary scheme.
 func ResolveAppScheme(requested string) string {
 	if IsAllowedAppScheme(requested) {
 		return requested
@@ -43,8 +34,6 @@ func ResolveAppScheme(requested string) string {
 	return DefaultAppScheme
 }
 
-// MagicLink is the stored test-account session the App Review magic link injects
-// into the app, bypassing the OAuth/2FA flow Apple's reviewers cannot complete.
 type MagicLink struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
@@ -60,8 +49,7 @@ type Proxy struct {
 	DeployedAt         string
 	GitSHA             string
 	MagicLink          *MagicLink
-	// MagicLinkAPIKey is the secret the magic route's ?key is checked against; empty disables it.
-	MagicLinkAPIKey string
+	MagicLinkAPIKey    string
 }
 
 func LoadEnv() (*Proxy, error) {
@@ -84,8 +72,6 @@ func LoadEnv() (*Proxy, error) {
 	}, nil
 }
 
-// parseMagicLink reads the optional MAGIC_LINK_BLOB env var; a missing or invalid
-// blob disables the magic link rather than failing boot.
 func parseMagicLink(raw string) *MagicLink {
 	if raw == "" {
 		return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -10,7 +12,45 @@ import (
 
 const (
 	defaultTwitchTimeout = 20 * time.Second
+	// DefaultAppScheme is the production app's custom URL scheme, used when a
+	// deployment doesn't set APP_SCHEME.
+	DefaultAppScheme = "foam"
 )
+
+// allowedAppSchemes are the custom URL schemes the Foam app registers, one per
+// build variant (see app.config.ts). Redirects are restricted to these so the
+// magic/proxy routes can't be used to bounce a token into an arbitrary scheme.
+var allowedAppSchemes = map[string]bool{
+	"foam":            true,
+	"foam-dev":        true,
+	"foam-internal":   true,
+	"foam-testflight": true,
+	"foam-e2e":        true,
+}
+
+// IsAllowedAppScheme reports whether scheme is a known Foam variant scheme.
+func IsAllowedAppScheme(scheme string) bool {
+	return allowedAppSchemes[scheme]
+}
+
+// ResolveAppScheme returns requested when it's a known variant scheme, otherwise
+// the production default. requested comes from the untrusted ?scheme query param,
+// so the allowlist stops the redirect from targeting an arbitrary scheme.
+func ResolveAppScheme(requested string) string {
+	if IsAllowedAppScheme(requested) {
+		return requested
+	}
+	return DefaultAppScheme
+}
+
+// MagicLink is the stored test-account session the App Review magic link injects
+// into the app, bypassing the OAuth/2FA flow Apple's reviewers cannot complete.
+type MagicLink struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
 
 type Proxy struct {
 	TwitchClientID     string
@@ -19,6 +59,9 @@ type Proxy struct {
 	DeployedBy         string
 	DeployedAt         string
 	GitSHA             string
+	MagicLink          *MagicLink
+	// MagicLinkAPIKey is the secret the magic route's ?key is checked against; empty disables it.
+	MagicLinkAPIKey string
 }
 
 func LoadEnv() (*Proxy, error) {
@@ -36,7 +79,30 @@ func LoadEnv() (*Proxy, error) {
 		DeployedBy:         os.Getenv("DEPLOYED_BY"),
 		DeployedAt:         os.Getenv("DEPLOYED_AT"),
 		GitSHA:             os.Getenv("GIT_SHA"),
+		MagicLink:          parseMagicLink(os.Getenv("MAGIC_LINK_BLOB")),
+		MagicLinkAPIKey:    os.Getenv("MAGIC_LINK_API_KEY"),
 	}, nil
+}
+
+// parseMagicLink reads the optional MAGIC_LINK_BLOB env var; a missing or invalid
+// blob disables the magic link rather than failing boot.
+func parseMagicLink(raw string) *MagicLink {
+	if raw == "" {
+		return nil
+	}
+
+	var magic MagicLink
+	if err := json.Unmarshal([]byte(raw), &magic); err != nil {
+		log.Printf("failed to parse MAGIC_LINK_BLOB: %v", err)
+		return nil
+	}
+
+	if magic.AccessToken == "" || magic.RefreshToken == "" {
+		log.Print("MAGIC_LINK_BLOB missing tokens; magic link disabled")
+		return nil
+	}
+
+	return &magic
 }
 
 func SentryOptions(dsn string) sentry.ClientOptions {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestResolveAppScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		want      string
+	}{
+		{"empty falls back to the production scheme", "", DefaultAppScheme},
+		{"production scheme is honoured", "foam", "foam"},
+		{"internal variant scheme is honoured", "foam-internal", "foam-internal"},
+		{"dev variant scheme is honoured", "foam-dev", "foam-dev"},
+		{"unknown scheme falls back to the production scheme", "foam-evil", DefaultAppScheme},
+		{"arbitrary url falls back to the production scheme", "https://evil.example", DefaultAppScheme},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveAppScheme(tt.requested); got != tt.want {
+				t.Fatalf("ResolveAppScheme(%q) = %q, want %q", tt.requested, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -2,8 +2,13 @@ package proxy
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
+	"html"
+	"net/url"
+	"strconv"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/foam/proxy/internal/config"
@@ -34,6 +39,8 @@ func (p *ProxyRequests) Handle(req *events.APIGatewayProxyRequest) Response {
 		return p.handleToken()
 	case "/api/refresh-token":
 		return p.handleRefreshToken(req)
+	case "/api/magic":
+		return p.handleMagic(req)
 	case "/api/healthcheck":
 		return p.handleHealth()
 	case "/api/version":
@@ -64,6 +71,17 @@ func (p *ProxyRequests) handleProxy() Response {
 		"target": "foam://",
 	})
 	return htmlResponse(200, redirectPage("Foam - Redirecting", "foam://"))
+}
+
+// resolveScheme picks the magic-link redirect scheme from the request's ?scheme
+// query param, validated against the variant allowlist; anything else falls back
+// to the production scheme.
+func resolveScheme(req *events.APIGatewayProxyRequest) string {
+	requested := ""
+	if req != nil && req.QueryStringParameters != nil {
+		requested = req.QueryStringParameters["scheme"]
+	}
+	return config.ResolveAppScheme(requested)
 }
 
 func (p *ProxyRequests) handleToken() Response {
@@ -103,6 +121,87 @@ func (p *ProxyRequests) handleRefreshToken(req *events.APIGatewayProxyRequest) R
 	return p.jsonResponse(200, map[string]interface{}{"data": data, "error": nil})
 }
 
+// handleMagic backs the App Review magic link, serving the stored session only
+// when ?key matches the configured secret. A missing or wrong key returns 404 so
+// the route never reveals its existence.
+func (p *ProxyRequests) handleMagic(req *events.APIGatewayProxyRequest) Response {
+	var magic *config.MagicLink
+	expectedKey := ""
+	if p.config != nil {
+		magic = p.config.MagicLink
+		expectedKey = p.config.MagicLinkAPIKey
+	}
+
+	key := ""
+	format := ""
+	if req.QueryStringParameters != nil {
+		key = req.QueryStringParameters["key"]
+		format = req.QueryStringParameters["format"]
+	}
+
+	if magic == nil || expectedKey == "" || key == "" {
+		return p.jsonResponse(404, map[string]string{"error": "not found"})
+	}
+
+	// Hash to fixed-length digests so the constant-time compare can't leak the secret's length.
+	providedKey := sha256.Sum256([]byte(key))
+	expected := sha256.Sum256([]byte(expectedKey))
+	if subtle.ConstantTimeCompare(providedKey[:], expected[:]) != 1 {
+		return p.jsonResponse(404, map[string]string{"error": "not found"})
+	}
+
+	// format=json returns the raw blob for in-app injection instead of the deep-link redirect.
+	if format == "json" {
+		safeLog("[AUTHDBG] magic link served", map[string]string{
+			"target": "json",
+		})
+		return noStore(p.jsonResponse(200, magicTokenBlob(magic)))
+	}
+
+	scheme := resolveScheme(req)
+	safeLog("[AUTHDBG] magic link served", map[string]string{
+		"target": scheme + "://auth",
+	})
+	return noStore(htmlResponse(200, redirectTargetPage("Foam - Signing in", magicTargetURL(magic, scheme))))
+}
+
+// magicTokenType returns the blob's token type, defaulting to "bearer".
+func magicTokenType(magic *config.MagicLink) string {
+	if magic.TokenType == "" {
+		return "bearer"
+	}
+	return magic.TokenType
+}
+
+func magicTokenBlob(magic *config.MagicLink) map[string]interface{} {
+	blob := map[string]interface{}{
+		"access_token": magic.AccessToken,
+		"token_type":   magicTokenType(magic),
+	}
+	if magic.RefreshToken != "" {
+		blob["refresh_token"] = magic.RefreshToken
+	}
+	if magic.ExpiresIn > 0 {
+		blob["expires_in"] = magic.ExpiresIn
+	}
+	return blob
+}
+
+func magicTargetURL(magic *config.MagicLink, scheme string) string {
+	form := url.Values{}
+	form.Set("access_token", magic.AccessToken)
+	if magic.RefreshToken != "" {
+		form.Set("refresh_token", magic.RefreshToken)
+	}
+	form.Set("token_type", magicTokenType(magic))
+
+	if magic.ExpiresIn > 0 {
+		form.Set("expires_in", strconv.Itoa(magic.ExpiresIn))
+	}
+
+	return scheme + "://auth?" + form.Encode()
+}
+
 func (p *ProxyRequests) handleVersion() Response {
 	out := map[string]string{
 		"deployedBy": "unknown",
@@ -129,6 +228,11 @@ func (p *ProxyRequests) jsonResponse(statusCode int, body interface{}) Response 
 		Headers:    DefaultHeaders(),
 		Body:       string(raw),
 	}
+}
+
+func noStore(resp Response) Response {
+	resp.Headers["Cache-Control"] = "no-store"
+	return resp
 }
 
 func htmlResponse(statusCode int, body string) Response {
@@ -181,6 +285,41 @@ func redirectPage(title, targetPrefix string) string {
     </script>
   </body>
 </html>`, title, targetPrefix, targetPrefix, targetPrefix)
+}
+
+func redirectTargetPage(title, target string) string {
+	hrefAttr := html.EscapeString(target)
+	jsTarget, _ := json.Marshal(target)
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <title>%s</title>
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+  </head>
+  <body>
+    <h1>Signing in…</h1>
+    <p>If nothing happens automatically, return to Foam.</p>
+    <a id="open-foam" href="%s">Open Foam</a>
+    <script data-cfasync="false">
+      const redirectUrl = %s;
+      const openFoam = document.getElementById('open-foam');
+
+      if (openFoam) {
+        openFoam.setAttribute('href', redirectUrl);
+      }
+
+      window.location.replace(redirectUrl);
+      setTimeout(() => {
+        window.location.href = redirectUrl;
+      }, 150);
+    </script>
+  </body>
+</html>`, title, hrefAttr, string(jsTarget))
 }
 
 func safeLog(message string, fields map[string]string) {

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -121,9 +121,6 @@ func (p *ProxyRequests) handleRefreshToken(req *events.APIGatewayProxyRequest) R
 	return p.jsonResponse(200, map[string]interface{}{"data": data, "error": nil})
 }
 
-// handleMagic backs the App Review magic link, serving the stored session only
-// when ?key matches the configured secret. A missing or wrong key returns 404 so
-// the route never reveals its existence.
 func (p *ProxyRequests) handleMagic(req *events.APIGatewayProxyRequest) Response {
 	var magic *config.MagicLink
 	expectedKey := ""
@@ -143,14 +140,12 @@ func (p *ProxyRequests) handleMagic(req *events.APIGatewayProxyRequest) Response
 		return p.jsonResponse(404, map[string]string{"error": "not found"})
 	}
 
-	// Hash to fixed-length digests so the constant-time compare can't leak the secret's length.
 	providedKey := sha256.Sum256([]byte(key))
 	expected := sha256.Sum256([]byte(expectedKey))
 	if subtle.ConstantTimeCompare(providedKey[:], expected[:]) != 1 {
 		return p.jsonResponse(404, map[string]string{"error": "not found"})
 	}
 
-	// format=json returns the raw blob for in-app injection instead of the deep-link redirect.
 	if format == "json" {
 		safeLog("[AUTHDBG] magic link served", map[string]string{
 			"target": "json",
@@ -162,10 +157,11 @@ func (p *ProxyRequests) handleMagic(req *events.APIGatewayProxyRequest) Response
 	safeLog("[AUTHDBG] magic link served", map[string]string{
 		"target": scheme + "://auth",
 	})
+
+	// return deep-link for app-store reviewer
 	return noStore(htmlResponse(200, redirectTargetPage("Foam - Signing in", magicTargetURL(magic, scheme))))
 }
 
-// magicTokenType returns the blob's token type, defaulting to "bearer".
 func magicTokenType(magic *config.MagicLink) string {
 	if magic.TokenType == "" {
 		return "bearer"

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -34,7 +34,7 @@ func TestProxyRequestsHandle(t *testing.T) {
 			request:     &events.APIGatewayProxyRequest{Path: "/api/proxy"},
 			statusCode:  200,
 			contentType: "text/html",
-			bodyParts:   []string{"Foam - Redirecting", "Open Foam"},
+			bodyParts:   []string{"Foam - Redirecting", "Open Foam", "foam://"},
 		},
 		{
 			name:        "health route returns json",
@@ -58,6 +58,13 @@ func TestProxyRequestsHandle(t *testing.T) {
 			bodyParts:   []string{`"error":"token query param is required"`},
 		},
 		{
+			name:        "magic route is hidden when unconfigured",
+			request:     &events.APIGatewayProxyRequest{Path: "/api/magic", QueryStringParameters: map[string]string{"key": "anything"}},
+			statusCode:  404,
+			contentType: "application/json",
+			bodyParts:   []string{`"error":"not found"`},
+		},
+		{
 			name:        "unknown path returns not found",
 			request:     &events.APIGatewayProxyRequest{Path: "/api/unknown"},
 			statusCode:  404,
@@ -78,6 +85,130 @@ func TestProxyRequestsHandle(t *testing.T) {
 			for _, bodyPart := range tt.bodyParts {
 				if !strings.Contains(response.Body, bodyPart) {
 					t.Fatalf("body %q does not contain %q", response.Body, bodyPart)
+				}
+			}
+		})
+	}
+}
+
+func TestProxyRequestsHandleMagic(t *testing.T) {
+	magic := &config.MagicLink{
+		AccessToken:  "ABC123",
+		RefreshToken: "REF456",
+		ExpiresIn:    14400,
+		TokenType:    "bearer",
+	}
+	proxyRequests := NewProxyRequests(&config.Proxy{
+		MagicLink:       magic,
+		MagicLinkAPIKey: "s3cret-review-key",
+	}, nil)
+
+	tests := []struct {
+		name        string
+		query       map[string]string
+		statusCode  int
+		contentType string
+		// wantParts must all be present in the body. For the success case these
+		// are the unescaped foam://auth deep link parts: the token reaches the
+		// app through the raw JS redirect URL, not the HTML-escaped href.
+		wantParts []string
+		// absentParts must never appear; the secret key must not be echoed back.
+		absentParts []string
+	}{
+		{
+			name:        "correct key redirects into the app with the stored token",
+			query:       map[string]string{"key": "s3cret-review-key"},
+			statusCode:  200,
+			contentType: "text/html",
+			wantParts: []string{
+				"foam://auth?",
+				"access_token=ABC123",
+				"refresh_token=REF456",
+				"token_type=bearer",
+				"expires_in=14400",
+			},
+			absentParts: []string{"s3cret-review-key"},
+		},
+		{
+			name:        "scheme override redirects into the requested variant app",
+			query:       map[string]string{"key": "s3cret-review-key", "scheme": "foam-internal"},
+			statusCode:  200,
+			contentType: "text/html",
+			wantParts: []string{
+				"foam-internal://auth?",
+				"access_token=ABC123",
+			},
+			// the production scheme must not be used when a valid variant is requested
+			absentParts: []string{"foam://auth?", "s3cret-review-key"},
+		},
+		{
+			name:        "unknown scheme override falls back to the production scheme",
+			query:       map[string]string{"key": "s3cret-review-key", "scheme": "https://evil.example"},
+			statusCode:  200,
+			contentType: "text/html",
+			wantParts: []string{
+				"foam://auth?",
+				"access_token=ABC123",
+			},
+			absentParts: []string{"evil.example", "s3cret-review-key"},
+		},
+		{
+			name:        "correct key with format=json returns the raw session blob",
+			query:       map[string]string{"key": "s3cret-review-key", "format": "json"},
+			statusCode:  200,
+			contentType: "application/json",
+			wantParts: []string{
+				`"access_token":"ABC123"`,
+				`"refresh_token":"REF456"`,
+				`"token_type":"bearer"`,
+				`"expires_in":14400`,
+			},
+			absentParts: []string{"foam://auth", "s3cret-review-key"},
+		},
+		{
+			name:        "wrong key with format=json is still indistinguishable from a missing route",
+			query:       map[string]string{"key": "wrong", "format": "json"},
+			statusCode:  404,
+			contentType: "application/json",
+			wantParts:   []string{`"error":"not found"`},
+		},
+		{
+			name:        "wrong key is indistinguishable from a missing route",
+			query:       map[string]string{"key": "wrong"},
+			statusCode:  404,
+			contentType: "application/json",
+			wantParts:   []string{`"error":"not found"`},
+		},
+		{
+			name:        "missing key returns not found",
+			query:       nil,
+			statusCode:  404,
+			contentType: "application/json",
+			wantParts:   []string{`"error":"not found"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := proxyRequests.Handle(&events.APIGatewayProxyRequest{
+				Path:                  "/api/magic",
+				QueryStringParameters: tt.query,
+			})
+
+			if response.StatusCode != tt.statusCode {
+				t.Fatalf("status code = %d, want %d", response.StatusCode, tt.statusCode)
+			}
+			if response.Headers["Content-Type"] != tt.contentType {
+				t.Fatalf("content type = %q, want %q", response.Headers["Content-Type"], tt.contentType)
+			}
+			for _, part := range tt.wantParts {
+				if !strings.Contains(response.Body, part) {
+					t.Fatalf("body does not contain %q\nbody: %s", part, response.Body)
+				}
+			}
+			for _, part := range tt.absentParts {
+				if strings.Contains(response.Body, part) {
+					t.Fatalf("body leaked %q\nbody: %s", part, response.Body)
 				}
 			}
 		})

--- a/internal/proxy/handlers_test.go
+++ b/internal/proxy/handlers_test.go
@@ -108,11 +108,7 @@ func TestProxyRequestsHandleMagic(t *testing.T) {
 		query       map[string]string
 		statusCode  int
 		contentType string
-		// wantParts must all be present in the body. For the success case these
-		// are the unescaped foam://auth deep link parts: the token reaches the
-		// app through the raw JS redirect URL, not the HTML-escaped href.
-		wantParts []string
-		// absentParts must never appear; the secret key must not be echoed back.
+		wantParts   []string
 		absentParts []string
 	}{
 		{
@@ -138,7 +134,6 @@ func TestProxyRequestsHandleMagic(t *testing.T) {
 				"foam-internal://auth?",
 				"access_token=ABC123",
 			},
-			// the production scheme must not be used when a valid variant is requested
 			absentParts: []string{"foam://auth?", "s3cret-review-key"},
 		},
 		{

--- a/scripts/refresh-magic-link.sh
+++ b/scripts/refresh-magic-link.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Keeps one environment's App Review magic link fresh. The app signs in with the
+# baked access_token immediately and never refreshes on failure, so a stale token
+# breaks the review login. Twitch user tokens last ~4h, so a cron runs this to
+# refresh the test-account token and write the new blob to the GitHub secret
+# (canonical) and the live Lambda env (immediate). One environment per run.
+#
+# Twitch binds a refresh token to its minting client id, so TWITCH_CLIENT_ID/SECRET
+# must match the blob being refreshed.
+#
+# Required env:
+#   MAGIC_LINK_BLOB       current blob JSON {access_token, refresh_token, ...}
+#   TWITCH_CLIENT_ID      Twitch client id the blob was minted with
+#   TWITCH_CLIENT_SECRET  Twitch client secret for that client id
+#   LAMBDA_FUNCTION_NAME  e.g. foam-proxy-lambda-production / -staging
+#   GH_TOKEN              PAT with "Secrets: write" to persist the rotated blob
+# Optional env:
+#   MAGIC_LINK_BLOB_SECRET  GitHub secret to write back to (default: MAGIC_LINK_BLOB)
+set -euo pipefail
+
+: "${MAGIC_LINK_BLOB:?MAGIC_LINK_BLOB is required}"
+: "${TWITCH_CLIENT_ID:?TWITCH_CLIENT_ID is required}"
+: "${TWITCH_CLIENT_SECRET:?TWITCH_CLIENT_SECRET is required}"
+: "${LAMBDA_FUNCTION_NAME:?LAMBDA_FUNCTION_NAME is required}"
+# Twitch rotates the refresh token on refresh, so the old one dies immediately. If
+# we can't persist the new blob the next terraform apply reverts the Lambda to the
+# dead token, so refuse to rotate rather than strand it.
+: "${GH_TOKEN:?GH_TOKEN is required to persist the rotated blob}"
+MAGIC_LINK_BLOB_SECRET="${MAGIC_LINK_BLOB_SECRET:-MAGIC_LINK_BLOB}"
+
+echo "::add-mask::${TWITCH_CLIENT_SECRET}"
+
+refresh_token=$(jq -r '.refresh_token // ""' <<<"${MAGIC_LINK_BLOB}")
+token_type=$(jq -r '.token_type // "bearer"' <<<"${MAGIC_LINK_BLOB}")
+[[ -n "${refresh_token}" ]] || { echo "MAGIC_LINK_BLOB has no refresh_token; cannot refresh" >&2; exit 1; }
+echo "::add-mask::${refresh_token}"
+
+# No -f: on an HTTP error curl -f drops the body, which under set -e aborts before
+# the new_access check and hides Twitch's error. -S still surfaces connection failures.
+response=$(curl -sS -X POST "https://id.twitch.tv/oauth2/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "client_id=${TWITCH_CLIENT_ID}" \
+  --data-urlencode "client_secret=${TWITCH_CLIENT_SECRET}" \
+  --data-urlencode "grant_type=refresh_token" \
+  --data-urlencode "refresh_token=${refresh_token}")
+
+new_access=$(jq -r '.access_token // ""' <<<"${response}")
+new_refresh=$(jq -r '.refresh_token // ""' <<<"${response}")
+expires_in=$(jq -r '.expires_in // 0' <<<"${response}")
+[[ -n "${new_access}" ]] || { echo "Twitch refresh failed: $(jq -rc '{status, message}' <<<"${response}" 2>/dev/null || echo "${response}")" >&2; exit 1; }
+echo "::add-mask::${new_access}"
+
+# Twitch usually rotates the refresh token; keep the old one only if it omits one.
+if [[ -n "${new_refresh}" ]]; then
+  echo "::add-mask::${new_refresh}"
+else
+  new_refresh="${refresh_token}"
+fi
+
+new_blob=$(jq -nc \
+  --arg access_token "${new_access}" \
+  --arg refresh_token "${new_refresh}" \
+  --arg token_type "${token_type}" \
+  --argjson expires_in "${expires_in}" \
+  '{access_token: $access_token, refresh_token: $refresh_token, expires_in: $expires_in, token_type: $token_type}')
+
+# 1) Persist the rotated blob to the canonical GitHub secret FIRST. If the Lambda
+#    update fails, the secret still holds the fresh blob and the next apply/run
+#    converges on it instead of reverting to the now-dead refresh token.
+printf '%s' "${new_blob}" | gh secret set "${MAGIC_LINK_BLOB_SECRET}"
+echo "Updated ${MAGIC_LINK_BLOB_SECRET} GitHub secret"
+
+# 2) Update the live Lambda env for immediate effect, merging into the existing
+#    variables so the rest (Twitch creds, DSNs) is preserved.
+current_env=$(aws lambda get-function-configuration \
+  --function-name "${LAMBDA_FUNCTION_NAME}" \
+  --query 'Environment.Variables' --output json)
+env_payload=$(jq -nc --argjson current "${current_env}" --arg blob "${new_blob}" \
+  '{Variables: ($current + {MAGIC_LINK_BLOB: $blob})}')
+aws lambda update-function-configuration \
+  --function-name "${LAMBDA_FUNCTION_NAME}" \
+  --environment "${env_payload}" >/dev/null
+
+echo "Refreshed magic link token on ${LAMBDA_FUNCTION_NAME} (expires_in=${expires_in}s)"

--- a/scripts/setup-magic-link.sh
+++ b/scripts/setup-magic-link.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Generates the App Review magic link values for ONE environment and PRINTS them
+# as JSON — it never writes to 1Password or GitHub (you store them). Run once per
+# env. See README "App Review magic link" for the full flow.
+#
+#   (default)   --env <prod|staging>   Mint a Twitch user token for the disposable
+#                                       test account, build the blob, and (prod
+#                                       only) generate the shared gate key.
+#   --verify    --env <prod|staging>   Fetch the live endpoint, confirm it returns a blob.
+#   --teardown                         Revoke the Twitch token and, when
+#                                       LAMBDA_FUNCTION_NAME is set, clear the live
+#                                       Lambda env so the route 404s immediately.
+#
+# Prompts/guidance go to stderr so stdout stays pipeable, e.g.
+#   scripts/setup-magic-link.sh --env prod -y | jq -r .magic_link_blob
+#
+# Prereqs: twitch, jq, shasum (setup); curl, jq (--verify); curl (--teardown,
+#          plus aws + jq to clear the live Lambda env).
+set -euo pipefail
+
+# Mirror of the scopes in foam src/hooks/useTwitchSignIn.ts — keep in sync
+# (one per line, same order, for easy diffing).
+SCOPES=(
+  user:read:follows
+  user:read:blocked_users
+  user:read:emotes
+  user:manage:blocked_users
+  chat:read
+  chat:edit
+  user:write:chat
+  moderator:read:chat_messages
+  moderator:manage:chat_messages
+  whispers:read
+  whispers:edit
+  channel:read:polls
+  channel:read:predictions
+  channel:read:redemptions
+  channel:moderate
+  channel:manage:clips
+  editor:manage:clips
+)
+
+# Shared gate key location (one key for both envs; prod setup mints it).
+OP_REF="op://ci-cd/foam-staging/MAGIC_LINK_API_KEY"
+EXPIRES_IN="${MAGIC_LINK_EXPIRES_IN:-14400}"
+
+MODE="setup"
+ENV_TARGET="" # prod|staging; required for setup and --verify
+AUTO_YES=0
+
+TOKEN_OUT=""
+trap '[[ -n "${TOKEN_OUT}" ]] && rm -f "${TOKEN_OUT}"; true' EXIT
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/setup-magic-link.sh [--teardown | --verify] --env <prod|staging> [--yes]
+
+Generates the magic-link blob and gate key for ONE env and prints JSON to stdout
+(blob, gate key, review URL); it does not store them. Prompts go to stderr.
+
+  (no flags)   Mint the token, build the blob, generate the gate key; print JSON.
+  --verify     Fetch the live <env> ?format=json endpoint and confirm a blob.
+  --teardown   Revoke the Twitch token; clears the live Lambda env when
+               LAMBDA_FUNCTION_NAME is set (you still clear the stored secrets).
+  --env <env>  Target environment: prod or staging (required for setup/--verify).
+  --yes, -y    Don't prompt for confirmation.
+EOF
+}
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "error: '$1' is required but not installed" >&2; exit 1; }; }
+
+confirm() {
+  [[ "${AUTO_YES}" -eq 1 ]] && return 0
+  local reply
+  read -rp "$1 [y/N] " reply
+  [[ "${reply}" =~ ^[Yy]([Ee][Ss])?$ ]]
+}
+
+base_url() {
+  case "$1" in
+    prod)    echo "https://auth.foam-app.com/api/magic" ;;
+    staging) echo "https://auth-staging.foam-app.com/api/magic" ;;
+    *)       return 1 ;;
+  esac
+}
+
+# Opaque high-entropy secret: SHA-256 of 32 random bytes -> 64 hex chars.
+gen_key() { head -c 32 /dev/urandom | shasum -a 256 | cut -d' ' -f1; }
+
+parse_token() {
+  local label="$1" text="$2"
+  printf '%s\n' "${text}" | grep -i "${label}" | tail -n1 | sed -E "s/.*${label}:[[:space:]]*//" | tr -d '[:space:]' || true
+}
+
+mint_token() {
+  local scope_str clean
+  scope_str="${SCOPES[*]}" # default IFS joins with spaces
+
+  cat >&2 <<EOF
+
+
+EOF
+
+  TOKEN_OUT="$(mktemp)"
+  if ! twitch token -u --dcf -s "${scope_str}" 2>&1 \
+       | tee "${TOKEN_OUT}" \
+       | sed -E -e $'s/\x1b\\[[0-9;]*m//g' -e 's/(Token):.*/\1: [redacted]/' >&2; then
+    echo "error: 'twitch token' failed" >&2
+    return 1
+  fi
+
+  clean="$(sed -E $'s/\x1b\\[[0-9;]*m//g' "${TOKEN_OUT}")"
+  ACCESS_TOKEN="$(parse_token 'User Access Token' "${clean}")"
+  REFRESH_TOKEN="$(parse_token 'Refresh Token' "${clean}")"
+
+  [[ -n "${ACCESS_TOKEN}"  ]] || { read -rsp "Could not parse access token — paste it: "  ACCESS_TOKEN;  echo; }
+  [[ -n "${REFRESH_TOKEN}" ]] || { read -rsp "Could not parse refresh token — paste it: " REFRESH_TOKEN; echo; }
+  [[ -n "${ACCESS_TOKEN}"  ]] || { echo "error: no access token" >&2; return 1; }
+  [[ -n "${REFRESH_TOKEN}" ]] || { echo "error: no refresh token (need 'twitch token -u --dcf')" >&2; return 1; }
+
+  echo "Parsed token (access …${ACCESS_TOKEN: -4}, refresh …${REFRESH_TOKEN: -4})." >&2
+}
+
+setup() {
+  need twitch; need jq; need shasum
+  local base; base="$(base_url "${ENV_TARGET}")" || { echo "error: setup requires --env prod|staging" >&2; exit 1; }
+
+  local key blob_secret key_dest
+  if [[ "${ENV_TARGET}" == "prod" ]]; then
+    key="$(gen_key)"
+    blob_secret="MAGIC_LINK_BLOB_PRODUCTION"
+    key_dest="${OP_REF} — the shared gate key (both deploys read it)"
+  else
+    key="${MAGIC_LINK_API_KEY:-}"
+    blob_secret="MAGIC_LINK_BLOB_STAGING"
+    key_dest="reuses the shared ${OP_REF} from prod setup — no separate staging key"
+  fi
+
+  echo "Setting up the ${ENV_TARGET} magic link." >&2
+  echo "The Twitch account must be a DISPOSABLE, low-privilege TEST account." >&2
+  confirm "Signed in to / about to sign in as a throwaway test account?" \
+    || { echo "Create one first, then re-run. Aborted." >&2; exit 1; }
+
+  if confirm "Configure the Twitch CLI for ${ENV_TARGET} now? (it prompts for client id/secret)"; then
+    twitch configure
+  fi
+
+  mint_token
+
+  local blob
+  blob="$(jq -nc \
+    --arg access_token "${ACCESS_TOKEN}" \
+    --arg refresh_token "${REFRESH_TOKEN}" \
+    --argjson expires_in "${EXPIRES_IN}" \
+    '{access_token: $access_token, refresh_token: $refresh_token, expires_in: $expires_in, token_type: "bearer"}')"
+
+  cat >&2 <<EOF
+
+============================================================================
+Generated ${ENV_TARGET} values — NOT stored anywhere. Copy them in yourself:
+  .magic_link_blob     -> GitHub secret '${blob_secret}'
+  .magic_link_api_key  -> ${key_dest}
+
+Next:
+  - Verify once stored + deployed:
+      MAGIC_LINK_API_KEY=${key} scripts/setup-magic-link.sh --verify --env ${ENV_TARGET}
+  - Seed the first refresh:  gh workflow run refresh-magic-link.yml
+  - After approval, revoke:  scripts/setup-magic-link.sh --teardown
+============================================================================
+
+EOF
+
+  jq -n \
+    --argjson blob "${blob}" \
+    --arg key "${key}" \
+    --arg env "${ENV_TARGET}" \
+    --arg base "${base}" \
+    '{
+      env: $env,
+      magic_link_blob: $blob,
+      magic_link_api_key: $key,
+      review_url: { browser: "\($base)?key=\($key)", json: "\($base)?key=\($key)&format=json" }
+    }'
+}
+
+# verify fetches the live ?format=json endpoint and confirms a session blob. A 404
+# means the key/blob has not reached the Lambda yet (deploy first) or the key is wrong.
+verify() {
+  need curl; need jq
+  local base; base="$(base_url "${ENV_TARGET}")" || { echo "error: --verify requires --env prod|staging" >&2; exit 1; }
+
+  local key="${MAGIC_LINK_API_KEY:-}"
+  [[ -n "${key}" ]] || { read -rsp "MAGIC_LINK_API_KEY for ${ENV_TARGET}: " key; echo; }
+  [[ -n "${key}" ]] || { echo "error: no key provided" >&2; exit 1; }
+
+  echo "GET ${base}?key=…&format=json" >&2
+  local resp; resp="$(curl -sS "${base}?key=${key}&format=json")"
+  if jq -e 'has("access_token") and (.access_token | length > 0)' >/dev/null 2>&1 <<<"${resp}"; then
+    echo "OK — ${ENV_TARGET} endpoint returned a session blob:" >&2
+    # Mask the token: show only its prefix so it doesn't land in scrollback.
+    jq '{access_token: (.access_token[0:6] + "…"), token_type, expires_in, has_refresh_token: has("refresh_token")}' <<<"${resp}"
+  else
+    echo "FAILED — no session blob (404 = key/blob not deployed yet, or wrong key):" >&2
+    printf '%s\n' "${resp}" >&2
+    exit 1
+  fi
+}
+
+teardown() {
+  need curl
+  echo "Revoke the Twitch token, then disable the live route." >&2
+
+  # Values taken interactively (env overrides for non-interactive use); nothing is
+  # read from 1Password/GitHub.
+  local client_id="${TWITCH_CLIENT_ID:-}" access="${MAGIC_LINK_ACCESS_TOKEN:-}"
+  [[ -n "${client_id}" ]] || read -rp "  Twitch client id the token was minted with: " client_id
+  [[ -n "${access}" ]] || { read -rsp "  Access token to revoke (empty to skip): " access; echo; }
+
+  if [[ -n "${client_id}" && -n "${access}" ]]; then
+    if confirm "  Revoke this token at Twitch?"; then
+      curl -sS -X POST "https://id.twitch.tv/oauth2/revoke" \
+        --data-urlencode "client_id=${client_id}" \
+        --data-urlencode "token=${access}" >/dev/null && echo "  revoked." >&2
+    fi
+  else
+    echo "  skipped token revoke (no client id / token)." >&2
+  fi
+
+  # The live route reads MAGIC_LINK_BLOB / MAGIC_LINK_API_KEY from the Lambda env at
+  # runtime, so clearing the stored secrets alone leaves the URL working until the next
+  # deploy. Strip them from the running Lambda now (merging into the existing variables
+  # so the rest survives) for an immediate 404. Mirrors refresh-magic-link.sh.
+  local lambda="${LAMBDA_FUNCTION_NAME:-}"
+  if [[ -n "${lambda}" ]] && command -v aws >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    if confirm "  Clear MAGIC_LINK_* from the live ${lambda} env now (immediate 404)?"; then
+      local current_env env_payload
+      current_env=$(aws lambda get-function-configuration \
+        --function-name "${lambda}" --query 'Environment.Variables' --output json)
+      [[ -n "${current_env}" && "${current_env}" != "null" ]] || current_env='{}'
+      env_payload=$(jq -nc --argjson current "${current_env}" \
+        '{Variables: ($current | del(.MAGIC_LINK_BLOB, .MAGIC_LINK_API_KEY))}')
+      aws lambda update-function-configuration \
+        --function-name "${lambda}" --environment "${env_payload}" >/dev/null
+      echo "  cleared MAGIC_LINK_BLOB / MAGIC_LINK_API_KEY on ${lambda}; route now 404s." >&2
+    fi
+  else
+    echo "  set LAMBDA_FUNCTION_NAME (with aws + jq installed) to clear the live env automatically." >&2
+  fi
+
+  cat >&2 <<EOF
+
+Now finish teardown yourself:
+  - Disconnect Foam from the test account: https://www.twitch.tv/settings/connections
+  - GitHub    : delete MAGIC_LINK_BLOB_STAGING / MAGIC_LINK_BLOB_PRODUCTION (and MAGIC_LINK_PAT)
+  - 1Password : clear ${OP_REF}
+Clear the stored secrets too, or the next deploy re-populates the Lambda env and revives the route.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --teardown) MODE="teardown" ;;
+    --verify)   MODE="verify" ;;
+    --env)      ENV_TARGET="${2:-}"; shift ;;
+    --env=*)    ENV_TARGET="${1#--env=}" ;;
+    -y|--yes)   AUTO_YES=1 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) echo "error: unknown argument '$1'" >&2; usage; exit 1 ;;
+  esac
+  shift
+done
+
+case "${MODE}" in
+  setup)    setup ;;
+  teardown) teardown ;;
+  verify)   verify ;;
+esac

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -127,6 +127,15 @@ resource "aws_apigatewayv2_route" "lambda_route_version" {
   operation_name = "get version"
 }
 
+# Public route (no authorizer): the App Review magic link is opened from Safari,
+# which cannot send an x-api-key header. The ?key secret in the URL gates it.
+resource "aws_apigatewayv2_route" "lambda_route_magic" {
+  api_id         = aws_apigatewayv2_api.lambda.id
+  target         = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  route_key      = "GET /api/magic"
+  operation_name = "get magic"
+}
+
 resource "aws_apigatewayv2_route" "lambda_route_token" {
   api_id             = aws_apigatewayv2_api.lambda.id
   target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -46,6 +46,8 @@ resource "aws_lambda_function" "lambda" {
       PROXY_DSN            = var.proxy_dsn
       SENTRY_ENVIRONMENT   = var.env
       SENTRY_RELEASE       = var.git_sha
+      MAGIC_LINK_BLOB      = var.magic_link_blob
+      MAGIC_LINK_API_KEY   = var.magic_link_api_key
     }
   }
   tags = merge(var.tags, {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -82,3 +82,17 @@ variable "proxy_dsn" {
   description = "the dsn of the authorizer sentry project"
   sensitive   = true
 }
+
+variable "magic_link_blob" {
+  type        = string
+  description = "JSON blob for the App Review magic link: {access_token, refresh_token, expires_in, token_type}. Empty disables the magic link."
+  default     = ""
+  sensitive   = true
+}
+
+variable "magic_link_api_key" {
+  type        = string
+  description = "Secret the magic route's ?key is compared against. Held separately from the magic_link_blob token data. Empty disables the magic link."
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
Changes:
* adds magic link API route for apple reviews to bypass twitch 2FA

Tasks to complete before merge:
* create alt twitch account and add blob to 1p secrets