### PR TITLE
chore(api): move sentry org

### DIFF
--- a/cmd/magic-keepalive/main.go
+++ b/cmd/magic-keepalive/main.go
@@ -19,6 +19,28 @@ func main() {
 	lambda.Start(handle)
 }
 
+const monitorSlug = "magic-link-keepalive"
+
+func keepaliveMonitor() *sentry.MonitorConfig {
+	return &sentry.MonitorConfig{
+		Schedule:              sentry.IntervalSchedule(3, sentry.MonitorScheduleUnitHour),
+		MaxRuntime:            5,
+		CheckInMargin:         10,
+		FailureIssueThreshold: 1,
+	}
+}
+
+func finishCheckIn(id *sentry.EventID, monitor *sentry.MonitorConfig, status sentry.CheckInStatus) {
+	if id == nil {
+		return
+	}
+	sentry.CaptureCheckIn(&sentry.CheckIn{
+		ID:          *id,
+		MonitorSlug: monitorSlug,
+		Status:      status,
+	}, monitor)
+}
+
 // handle runs on an EventBridge schedule. It is a no-op unless
 // REVIEWER_ACCOUNT_REFRESH_ENABLED is true, so the token is only kept warm (and
 // SSM only touched) during App Review windows.
@@ -28,18 +50,32 @@ func handle(ctx context.Context) error {
 		return nil
 	}
 
+	monitor := keepaliveMonitor()
+	checkInID := sentry.CaptureCheckIn(&sentry.CheckIn{
+		MonitorSlug: monitorSlug,
+		Status:      sentry.CheckInStatusInProgress,
+	}, monitor)
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("monitor", sentry.Context{"slug": monitorSlug})
+	})
+
 	if err := run(ctx); err != nil {
 		log.Printf("magic link keepalive failed: %v", err)
-		// Already rotated: expected, non-retryable. Return nil so EventBridge
-		// doesn't re-invoke, and skip Sentry. Pre-refresh failures stay retryable.
+		// Already rotated: expected, non-retryable. Close the check-in OK and return
+		// nil so EventBridge doesn't re-invoke. Pre-refresh failures stay retryable.
 		if errors.Is(err, magickeepalive.ErrTokenRotated) {
+			finishCheckIn(checkInID, monitor, sentry.CheckInStatusOK)
+			sentry.Flush(2 * time.Second)
 			return nil
 		}
+		finishCheckIn(checkInID, monitor, sentry.CheckInStatusError)
 		sentry.CaptureException(err)
 		sentry.Flush(2 * time.Second)
 		return err
 	}
 
+	finishCheckIn(checkInID, monitor, sentry.CheckInStatusOK)
+	sentry.Flush(2 * time.Second)
 	log.Print("refreshed magic link keepalive token")
 	return nil
 }

--- a/cmd/magic-keepalive/main.go
+++ b/cmd/magic-keepalive/main.go
@@ -61,10 +61,12 @@ func handle(ctx context.Context) error {
 
 	if err := run(ctx); err != nil {
 		log.Printf("magic link keepalive failed: %v", err)
-		// Already rotated: expected, non-retryable. Close the check-in OK and return
-		// nil so EventBridge doesn't re-invoke. Pre-refresh failures stay retryable.
+		// Already rotated: the token is dead, so retrying is futile. Close the
+		// check-in as error to surface the dead-token state, but return nil so
+		// EventBridge doesn't re-invoke. Pre-refresh failures stay retryable.
 		if errors.Is(err, magickeepalive.ErrTokenRotated) {
-			finishCheckIn(checkInID, monitor, sentry.CheckInStatusOK)
+			finishCheckIn(checkInID, monitor, sentry.CheckInStatusError)
+			sentry.CaptureException(err)
 			sentry.Flush(2 * time.Second)
 			return nil
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,13 +114,36 @@ func SentryOptions(dsn string) sentry.ClientOptions {
 	return sentry.ClientOptions{
 		Dsn:              dsn,
 		Environment:      os.Getenv("SENTRY_ENVIRONMENT"),
-		Release:          os.Getenv("SENTRY_RELEASE"),
+		Release:          sentryRelease(),
 		AttachStacktrace: true,
 		SampleRate:       1.0,
 		EnableTracing:    true,
-		TracesSampleRate: 0.5,
+		TracesSampleRate: 1,
 		MaxBreadcrumbs:   50,
 		SendDefaultPII:   false,
 		Debug:            false,
+		EnableLogs:       true,
+		Tags:             sentryDefaultTags(),
 	}
+}
+
+func sentryRelease() string {
+	if release := os.Getenv("SENTRY_RELEASE"); release != "" {
+		return release
+	}
+	return os.Getenv("GIT_SHA")
+}
+
+func sentryDefaultTags() map[string]string {
+	tags := map[string]string{}
+	for key, env := range map[string]string{
+		"git_sha":     "GIT_SHA",
+		"deployed_by": "DEPLOYED_BY",
+		"deployed_at": "DEPLOYED_AT",
+	} {
+		if v := os.Getenv(env); v != "" {
+			tags[key] = v
+		}
+	}
+	return tags
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,45 @@ func TestInitSentryNoOpWithEmptyDSN(t *testing.T) {
 	}
 }
 
+func TestSentryReleasePrefersEnvThenGitSHA(t *testing.T) {
+	t.Run("SENTRY_RELEASE wins", func(t *testing.T) {
+		t.Setenv("SENTRY_RELEASE", "v1.2.3")
+		t.Setenv("GIT_SHA", "abc123")
+		if got := sentryRelease(); got != "v1.2.3" {
+			t.Fatalf("sentryRelease() = %q, want v1.2.3", got)
+		}
+	})
+	t.Run("falls back to GIT_SHA", func(t *testing.T) {
+		t.Setenv("SENTRY_RELEASE", "")
+		t.Setenv("GIT_SHA", "abc123")
+		if got := sentryRelease(); got != "abc123" {
+			t.Fatalf("sentryRelease() = %q, want abc123", got)
+		}
+	})
+}
+
+func TestSentryOptionsCarriesReleaseTagsAndMetrics(t *testing.T) {
+	t.Setenv("SENTRY_RELEASE", "")
+	t.Setenv("GIT_SHA", "deadbeef")
+	t.Setenv("DEPLOYED_BY", "ci")
+	t.Setenv("DEPLOYED_AT", "")
+
+	opts := SentryOptions("https://example@sentry.io/1")
+
+	if opts.Release != "deadbeef" {
+		t.Fatalf("Release = %q, want deadbeef (source context needs a commit-linked release)", opts.Release)
+	}
+	if opts.DisableMetrics {
+		t.Fatal("DisableMetrics should be false so the Meter API emits APM metrics")
+	}
+	if opts.Tags["git_sha"] != "deadbeef" || opts.Tags["deployed_by"] != "ci" {
+		t.Fatalf("default tags = %v, want git_sha/deployed_by populated", opts.Tags)
+	}
+	if _, ok := opts.Tags["deployed_at"]; ok {
+		t.Fatalf("empty env vars should be omitted from tags, got %v", opts.Tags)
+	}
+}
+
 func TestResolveAppScheme(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -120,7 +120,7 @@ func (handler *Handler) HandleRequest(ctx context.Context, input *events.APIGate
 			Category: "request",
 			Message:  method + " " + input.Path,
 			Level:    sentry.LevelInfo,
-			Data:     map[string]interface{}{"request_id": requestID},
+			Data:     map[string]any{"request_id": requestID},
 		}, 0)
 	})
 
@@ -140,7 +140,7 @@ func (handler *Handler) HandleRequest(ctx context.Context, input *events.APIGate
 	tx.Status = spanStatusForHTTP(response.StatusCode)
 	statusAttr := sentry.WithAttributes(attribute.Int("http.status_code", response.StatusCode))
 	meter.Count("proxy.response", 1, statusAttr)
-	meter.Distribution("proxy.request.duration_ms", float64(elapsed.Milliseconds()), sentry.WithUnit("millisecond"), statusAttr)
+	meter.Distribution("proxy.request.duration_ms", float64(elapsed.Milliseconds()), sentry.WithUnit(sentry.UnitMillisecond), statusAttr)
 
 	return &events.APIGatewayProxyResponse{
 		StatusCode: response.StatusCode,
@@ -186,7 +186,7 @@ func mustJSON(value map[string]string) string {
 	return string(raw)
 }
 
-func apiResponse(status int, headers map[string]string, body interface{}) *events.APIGatewayProxyResponse {
+func apiResponse(status int, headers map[string]string, body any) *events.APIGatewayProxyResponse {
 	raw, err := json.Marshal(body)
 	if err != nil {
 		raw = []byte(`{"error":"internal server error"}`)

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/foam/proxy/internal/magiclink"
 	"github.com/foam/proxy/internal/proxy/services"
 	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/attribute"
 )
 
 type Handler struct {
@@ -107,15 +108,64 @@ func (handler *Handler) HandleRequest(ctx context.Context, input *events.APIGate
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
 		scope.SetTag("request_id", requestID)
 		scope.SetTag("path", input.Path)
+		scope.SetTag("http.method", method)
+		scope.SetContext("request", sentry.Context{
+			"id":     requestID,
+			"url":    requestURL,
+			"method": method,
+			"path":   input.Path,
+			"query":  sanitizeQuery(input.QueryStringParameters),
+		})
+		scope.AddBreadcrumb(&sentry.Breadcrumb{
+			Category: "request",
+			Message:  method + " " + input.Path,
+			Level:    sentry.LevelInfo,
+			Data:     map[string]interface{}{"request_id": requestID},
+		}, 0)
 	})
+
+	meter := sentry.NewMeter(tx.Context())
+	meter.SetAttributes(
+		attribute.String("http.method", method),
+		attribute.String("http.route", input.Path),
+	)
+	meter.Count("proxy.request", 1)
+
+	start := time.Now()
 	log.Printf(`{"level":"info","msg":"request","request_id":%q,"path":%q,"url":%q,"method":%q,"query":%s,"query_keys":%q}`, requestID, input.Path, requestURL, method, mustJSON(sanitizeQuery(input.QueryStringParameters)), sortedKeys(input.QueryStringParameters))
 	response := handler.proxyRequests.Handle(input)
+	elapsed := time.Since(start)
 	log.Printf(`{"level":"info","msg":"response","request_id":%q,"path":%q,"status":%d,"content_type":%q,"location":%q,"body_preview":%q}`, requestID, input.Path, response.StatusCode, response.Headers["Content-Type"], response.Headers["Location"], bodyPreview(response.Body))
+
+	tx.Status = spanStatusForHTTP(response.StatusCode)
+	statusAttr := sentry.WithAttributes(attribute.Int("http.status_code", response.StatusCode))
+	meter.Count("proxy.response", 1, statusAttr)
+	meter.Distribution("proxy.request.duration_ms", float64(elapsed.Milliseconds()), sentry.WithUnit("millisecond"), statusAttr)
+
 	return &events.APIGatewayProxyResponse{
 		StatusCode: response.StatusCode,
 		Headers:    response.Headers,
 		Body:       response.Body,
 	}, nil
+}
+
+func spanStatusForHTTP(status int) sentry.SpanStatus {
+	switch {
+	case status >= 200 && status < 400:
+		return sentry.SpanStatusOK
+	case status == 401:
+		return sentry.SpanStatusUnauthenticated
+	case status == 403:
+		return sentry.SpanStatusPermissionDenied
+	case status == 404:
+		return sentry.SpanStatusNotFound
+	case status == 429:
+		return sentry.SpanStatusResourceExhausted
+	case status >= 400 && status < 500:
+		return sentry.SpanStatusInvalidArgument
+	default:
+		return sentry.SpanStatusInternalError
+	}
 }
 
 func bodyPreview(body string) string {


### PR DESCRIPTION
**Changes:**
Moves sentry org to `foam-tv` in addition to enriching some events + adding cron monitoring for the app-store review refresher